### PR TITLE
ComponentBindingAdapter

### DIFF
--- a/arch/src/main/java/knaufdan/android/arch/base/component/ComponentBindingAdapters.kt
+++ b/arch/src/main/java/knaufdan/android/arch/base/component/ComponentBindingAdapters.kt
@@ -21,7 +21,7 @@ fun ViewGroup.bindComponents(components: List<IComponent<*>>?) {
     if (hasComponents(components)) {
         return
     }
-    parentComponents[this] = components
+    parentComponents[this] = components.toList()
 
     removeAllViewsInLayout()
 


### PR DESCRIPTION
- store components as new copy of component list instead of holding direct reference

bug: #75 