### PR TITLE
Live data extensions

### DIFF
--- a/arch/src/main/java/knaufdan/android/arch/base/component/recyclerview/implementation/ComponentViewHolder.kt
+++ b/arch/src/main/java/knaufdan/android/arch/base/component/recyclerview/implementation/ComponentViewHolder.kt
@@ -12,9 +12,7 @@ class ComponentViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
     private lateinit var component: IComponent<Any>
 
-    fun bind(
-        component: IComponent<Any>
-    ) {
+    fun bind(component: IComponent<Any>) {
         this.component = component
 
         binding.apply {

--- a/arch/src/main/java/knaufdan/android/arch/databinding/livedata/MutableLiveDataExtentions.kt
+++ b/arch/src/main/java/knaufdan/android/arch/databinding/livedata/MutableLiveDataExtentions.kt
@@ -19,8 +19,8 @@ fun <T> MutableLiveData<List<T>>.add(
     }
 
     items.add(
-        index,
-        newItem
+        index = index,
+        element = newItem
     )
 
     value = items
@@ -41,8 +41,8 @@ fun <T> MutableLiveData<List<T>>.addAll(
     }
 
     items.addAll(
-        index,
-        newItems.toList()
+        index = index,
+        elements = newItems.toList()
     )
 
     value = items

--- a/arch/src/main/java/knaufdan/android/arch/databinding/livedata/MutableLiveDataExtentions.kt
+++ b/arch/src/main/java/knaufdan/android/arch/databinding/livedata/MutableLiveDataExtentions.kt
@@ -1,0 +1,70 @@
+package knaufdan.android.arch.databinding.livedata
+
+import androidx.annotation.MainThread
+import androidx.lifecycle.MutableLiveData
+import knaufdan.android.core.util.extensions.validateIndex
+
+@MainThread
+fun <T> MutableLiveData<List<T>>.add(
+    newItem: T,
+    index: Int = UNSPECIFIED_INDEX
+) {
+    val items = value?.toMutableList() ?: mutableListOf()
+
+    val isInvalidIndex = !items.validateIndex(index)
+    if (isInvalidIndex) {
+        items.add(newItem)
+        value = items
+        return
+    }
+
+    items.add(
+        index,
+        newItem
+    )
+
+    value = items
+}
+
+@MainThread
+fun <T> MutableLiveData<List<T>>.addAll(
+    vararg newItems: T,
+    index: Int = UNSPECIFIED_INDEX
+) {
+    val items = value?.toMutableList() ?: mutableListOf()
+
+    val isInvalidIndex = !items.validateIndex(index)
+    if (isInvalidIndex) {
+        items.addAll(newItems)
+        value = items
+        return
+    }
+
+    items.addAll(
+        index,
+        newItems.toList()
+    )
+
+    value = items
+}
+
+@MainThread
+fun <T> MutableLiveData<List<T>>.remove(index: Int) {
+    val items = value?.toMutableList() ?: return
+
+    val isInvalidIndex = !items.validateIndex(index)
+    if (isInvalidIndex) {
+        return
+    }
+
+    items.removeAt(index)
+
+    value = items
+}
+
+@MainThread
+fun <T> MutableLiveData<List<T>>.clear() {
+    value = emptyList()
+}
+
+private const val UNSPECIFIED_INDEX = -1

--- a/arch/src/main/java/knaufdan/android/arch/databinding/views/NumberPickerBindingAdapters.kt
+++ b/arch/src/main/java/knaufdan/android/arch/databinding/views/NumberPickerBindingAdapters.kt
@@ -25,9 +25,11 @@ fun NumberPicker.setup(
     wrapSelectorWheel = isWrapped
 
     // NOTE: workaround for a bug that rendered the selected value wrong until user scrolled, see also: https://stackoverflow.com/q/27343772/3451975
-    (NumberPicker::class.java.getDeclaredField("mInputText")
-        .apply { isAccessible = true }
-        .get(this) as EditText)
+    (
+        NumberPicker::class.java.getDeclaredField("mInputText")
+            .apply { isAccessible = true }
+            .get(this) as EditText
+        )
         .filters = emptyArray()
 }
 

--- a/core/src/main/java/knaufdan/android/core/util/extensions/CollectionExtensions.kt
+++ b/core/src/main/java/knaufdan/android/core/util/extensions/CollectionExtensions.kt
@@ -1,0 +1,3 @@
+package knaufdan.android.core.util.extensions
+
+fun Collection<*>.validateIndex(index: Int): Boolean = index in this.indices


### PR DESCRIPTION
- create extensions on the MutableLiveData class to ease the use of list as datatype
- create a collection extension to validate a given index