### PR TITLE
Maintain/delete duplicate type alias

### DIFF
--- a/arch/src/main/java/knaufdan/android/arch/base/BindingKey.kt
+++ b/arch/src/main/java/knaufdan/android/arch/base/BindingKey.kt
@@ -1,0 +1,3 @@
+package knaufdan.android.arch.base
+
+typealias BindingKey = Int

--- a/arch/src/main/java/knaufdan/android/arch/base/LayoutRes.kt
+++ b/arch/src/main/java/knaufdan/android/arch/base/LayoutRes.kt
@@ -1,0 +1,3 @@
+package knaufdan.android.arch.base
+
+typealias LayoutRes = Int

--- a/arch/src/main/java/knaufdan/android/arch/base/component/IComponent.kt
+++ b/arch/src/main/java/knaufdan/android/arch/base/component/IComponent.kt
@@ -1,9 +1,8 @@
 package knaufdan.android.arch.base.component
 
+import knaufdan.android.arch.base.BindingKey
 import knaufdan.android.arch.base.IGenericType
-
-typealias LayoutRes = Int
-typealias BindingKey = Int
+import knaufdan.android.arch.base.LayoutRes
 
 interface IComponent<DataSource> : IGenericType<DataSource> {
     /**

--- a/arch/src/main/java/knaufdan/android/arch/base/component/text/implementation/TextComponent.kt
+++ b/arch/src/main/java/knaufdan/android/arch/base/component/text/implementation/TextComponent.kt
@@ -2,8 +2,8 @@ package knaufdan.android.arch.base.component.text.implementation
 
 import knaufdan.android.arch.BR
 import knaufdan.android.arch.R
-import knaufdan.android.arch.base.component.BindingKey
-import knaufdan.android.arch.base.component.LayoutRes
+import knaufdan.android.arch.base.BindingKey
+import knaufdan.android.arch.base.LayoutRes
 import knaufdan.android.arch.base.component.text.ITextComponent
 import knaufdan.android.arch.base.component.text.TextConfig
 import knaufdan.android.core.resources.IResourceProvider

--- a/arch/src/main/java/knaufdan/android/arch/mvvm/IAndroidComponent.kt
+++ b/arch/src/main/java/knaufdan/android/arch/mvvm/IAndroidComponent.kt
@@ -1,10 +1,9 @@
 package knaufdan.android.arch.mvvm
 
+import knaufdan.android.arch.base.BindingKey
 import knaufdan.android.arch.base.IGenericType
+import knaufdan.android.arch.base.LayoutRes
 import knaufdan.android.core.resources.IResourceProvider
-
-typealias LayoutRes = Int
-typealias BindingKey = Int
 
 interface IAndroidComponent<ViewModel : IAndroidBaseViewModel> : IGenericType<ViewModel> {
     /**

--- a/services/src/main/java/knaufdan/android/services/alarm/AlarmService.kt
+++ b/services/src/main/java/knaufdan/android/services/alarm/AlarmService.kt
@@ -6,10 +6,10 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import knaufdan.android.core.IContextProvider
-import knaufdan.android.core.alarm.IAlarmService
 import javax.inject.Inject
 import javax.inject.Singleton
+import knaufdan.android.core.IContextProvider
+import knaufdan.android.core.alarm.IAlarmService
 
 @Singleton
 internal class AlarmService @Inject constructor(private val contextProvider: IContextProvider) :


### PR DESCRIPTION
- BindingKey and LayoutRes alias were defined twice
- delete on in arch.mvvm and define it only in arch.base