### PR TITLE
Dependency Replacement

### DIFF
--- a/core/src/main/java/knaufdan/android/core/preferences/ISharedPrefsServiceConfig.kt
+++ b/core/src/main/java/knaufdan/android/core/preferences/ISharedPrefsServiceConfig.kt
@@ -12,7 +12,7 @@ interface ISharedPrefsServiceConfig {
 
     @Deprecated(
         message = "Will be replaced in 0.11.0 by setFileName(name)",
-        replaceWith = ReplaceWith("setFileName(name)")
+        replaceWith = ReplaceWith("setFileName(location)")
     )
     fun setLocation(location: String)
 


### PR DESCRIPTION
- to use previous value you must use the name of the previous value